### PR TITLE
Big cluster

### DIFF
--- a/big_cluster.py
+++ b/big_cluster.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from avocado import main
+
+from sdcm.tester import ClusterTester
+
+
+class HugeClusterTest(ClusterTester):
+
+    """
+    Test a huge Scylla cluster
+
+    :avocado: enable
+    """
+
+    def test_huge(self):
+        """
+        Test a huge Scylla cluster
+        """
+        self.run_stress(duration=20)
+
+if __name__ == '__main__':
+    main()

--- a/data_dir/big-cluster.yaml
+++ b/data_dir/big-cluster.yaml
@@ -1,0 +1,32 @@
+# default cassandra stress duration (min) if none specified
+duration: 20
+# default cassandra stress thread number if none specified
+threads: 4
+n_db_nodes: 40
+# I have to solve a problem with SSH connection parallelism, until then
+# keep n_loaders: 1
+n_loaders: 1
+instance_type_db: 't2.micro'
+instance_type_loader: 't2.micro'
+
+regions: !mux
+    us_west_2:
+        region_name: 'us-west-2'
+        security_group_ids: 'sg-81703ae4'
+        subnet_id: 'subnet-5207ee37'
+        ami_id_db_scylla: 'ami-ac4f69c6'
+        ami_id_db_cassandra: 'ami-1cff962c'
+        ami_id_loader: 'ami-05f4ed35'
+    us_east_1:
+        region_name: 'us-east-1'
+        security_group_ids: 'sg-c5e1f7a0'
+        subnet_id: 'subnet-ec4a72c4'
+        ami_id_db_scylla: 'ami-ac4f69c6'
+        ami_id_db_cassandra: 'ami-ada2b6c4'
+        ami_id_loader: 'ami-a51564c0'
+
+databases: !mux
+    cassandra:
+        db_type: cassandra
+    scylla:
+        db_type: scylla

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -80,8 +80,7 @@ class Nemesis(object):
     def disrupt_kill_scylla_daemon(self):
         print('{}: Kill all scylla processes in {}'.format(self,
                                                            self.target_node))
-        kill_cmd = ("for pid in $(ps -ef | awk '/scylla/ {print $2}'); "
-                    "do sudo kill -9 $pid; done")
+        kill_cmd = ("sudo pkill -9 scylla)")
         self.target_node.remoter.run(kill_cmd, ignore_status=True)
 
         def scylla_service_down():


### PR DESCRIPTION

I can you can to test is it's the big cluster test.

It is failing in SSH timeouts because the first node of the cluster never initialize.
(That can be seen in the EC2 interface.)

Maybe if you reproduce it we could fill a bug tomorow.