### PR TITLE
sdcm.cluster: Fix one last place with wrong str interpolation marker

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -158,7 +158,7 @@ class Node(object):
         self.instance.start()
         self.instance.wait_until_running()
         self.wait_public_ip()
-        self.log.debug('Got new public IP {}',
+        self.log.debug('Got new public IP %s',
                        self.instance.public_ip_address)
         self.remoter.hostname = self.instance.public_ip_address
         self.wait_db_up()


### PR DESCRIPTION
Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>