### PR TITLE
cluster tests: Introduce cluster/node prefixes

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -12,6 +12,9 @@ instance_type_loader: 't2.micro'
 nemesis_class_name: 'StopStartMonkey'
 # Nemesis sleep interval to use if None provided specifically
 nemesis_interval: 15
+# Prefix for your AWS VMs (handy for telling instances from different
+# users apart). If you leave this empty, the prefix will be your unix username.
+user_prefix:
 
 regions: !mux
     us_west_2:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -13,6 +13,7 @@
 
 import Queue
 import atexit
+import getpass
 import logging
 import os
 import tempfile
@@ -39,6 +40,7 @@ SCYLLA_CLUSTER_DEVICE_MAPPINGS = [{"DeviceName": "/dev/xvdb",
 
 CREDENTIALS = []
 EC2_INSTANCES = []
+DEFAULT_USER_PREFIX = getpass.getuser()
 
 
 def cleanup_instances():
@@ -78,15 +80,22 @@ class LoaderSetInitError(Exception):
     pass
 
 
+def _prepend_user_prefix(user_prefix, base_name):
+    if user_prefix is None:
+        user_prefix = DEFAULT_USER_PREFIX
+    return '%s-%s' % (user_prefix, base_name)
+
+
 class RemoteCredentials(object):
 
     """
     Wraps EC2.KeyPair, so that we can save keypair info into .pem files.
     """
 
-    def __init__(self, service, key_prefix='keypair'):
+    def __init__(self, service, key_prefix='keypair', user_prefix=None):
         self.uuid = uuid.uuid4()
         self.shortid = str(self.uuid)[:8]
+        key_prefix = _prepend_user_prefix(user_prefix, key_prefix)
         self.name = '%s-%s' % (key_prefix, self.shortid)
         self.key_pair = service.create_key_pair(KeyName=self.name)
         self.key_file = os.path.join(tempfile.gettempdir(),
@@ -318,10 +327,12 @@ class ScyllaCluster(Cluster):
                  service, credentials, ec2_instance_type='c4.xlarge',
                  ec2_ami_username='centos',
                  ec2_block_device_mappings=None,
+                 user_prefix=None,
                  n_nodes=10):
         # We have to pass the cluster name in advance in user_data
         cluster_uuid = uuid.uuid4()
-        cluster_prefix = 'scylla-db-cluster'
+        cluster_prefix = _prepend_user_prefix(user_prefix, 'scylla-db-cluster')
+        node_prefix = _prepend_user_prefix(user_prefix, 'scylla-db-node')
         shortid = str(cluster_uuid)[:8]
         name = '%s-%s' % (cluster_prefix, shortid)
         user_data = ('--clustername %s '
@@ -337,7 +348,7 @@ class ScyllaCluster(Cluster):
                                             service=service,
                                             credentials=credentials,
                                             cluster_prefix=cluster_prefix,
-                                            node_prefix='scylla-db-node',
+                                            node_prefix=node_prefix,
                                             n_nodes=n_nodes)
         self.nemesis = []
         self.nemesis_threads = []
@@ -473,17 +484,21 @@ class CassandraCluster(ScyllaCluster):
                  service, credentials, ec2_instance_type='c4.xlarge',
                  ec2_ami_username='ubuntu',
                  ec2_block_device_mappings=None,
+                 user_prefix=None,
                  n_nodes=10):
         if ec2_block_device_mappings is None:
             ec2_block_device_mappings = []
         # We have to pass the cluster name in advance in user_data
         cluster_uuid = uuid.uuid4()
-        cluster_prefix = 'cassandra-db-cluster'
+        cluster_prefix = _prepend_user_prefix(user_prefix,
+                                              'cassandra-db-cluster')
+        node_prefix = _prepend_user_prefix(user_prefix, 'cassandra-db-node')
         shortid = str(cluster_uuid)[:8]
         name = '%s-%s' % (cluster_prefix, shortid)
         user_data = ('--clustername %s '
                      '--totalnodes %s --version community '
                      '--release 2.1.8' % (name, n_nodes))
+
         super(ScyllaCluster, self).__init__(ec2_ami_id=ec2_ami_id,
                                             ec2_subnet_id=ec2_subnet_id,
                                             ec2_security_group_ids=ec2_security_group_ids,
@@ -495,7 +510,7 @@ class CassandraCluster(ScyllaCluster):
                                             service=service,
                                             credentials=credentials,
                                             cluster_prefix=cluster_prefix,
-                                            node_prefix='cassandra-db-node',
+                                            node_prefix=node_prefix,
                                             n_nodes=n_nodes)
         self.nemesis = []
         self.nemesis_threads = []
@@ -560,7 +575,10 @@ class LoaderSet(Cluster):
     def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,
                  service, credentials, ec2_instance_type='c4.xlarge',
                  ec2_block_device_mappings=None,
-                 ec2_ami_username='centos', scylla_repo=None, n_nodes=10):
+                 ec2_ami_username='centos', scylla_repo=None,
+                 user_prefix=None, n_nodes=10):
+        node_prefix = _prepend_user_prefix(user_prefix, 'scylla-loader-node')
+        cluster_prefix = _prepend_user_prefix(user_prefix, 'scylla-loader-set')
         super(LoaderSet, self).__init__(ec2_ami_id=ec2_ami_id,
                                         ec2_subnet_id=ec2_subnet_id,
                                         ec2_security_group_ids=ec2_security_group_ids,
@@ -569,8 +587,8 @@ class LoaderSet(Cluster):
                                         service=service,
                                         ec2_block_device_mappings=ec2_block_device_mappings,
                                         credentials=credentials,
-                                        cluster_prefix='scylla-loader-set',
-                                        node_prefix='scylla-loader-node',
+                                        cluster_prefix=cluster_prefix,
+                                        node_prefix=node_prefix,
                                         n_nodes=n_nodes)
         self.scylla_repo = scylla_repo
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -75,10 +75,12 @@ class ClusterTester(Test):
             loaders_type = self.params.get('instance_type_loader')
         if dbs_type is None:
             dbs_type = self.params.get('instance_type_db')
+        user_prefix = self.params.get('user_prefix', None)
         session = boto3.session.Session(region_name=self.params.get('region_name'))
         service = session.resource('ec2')
         self.credentials = RemoteCredentials(service=service,
-                                             key_prefix='longevity-test')
+                                             key_prefix='longevity-test',
+                                             user_prefix=user_prefix)
 
         if self.params.get('db_type') == 'scylla':
             self.db_cluster = ScyllaCluster(ec2_ami_id=self.params.get('ami_id_db_scylla'),
@@ -88,6 +90,7 @@ class ClusterTester(Test):
                                             service=service,
                                             credentials=self.credentials,
                                             ec2_block_device_mappings=dbs_block_device_mappings,
+                                            user_prefix=user_prefix,
                                             n_nodes=n_db_nodes)
         elif self.params.get('db_type') == 'cassandra':
             self.db_cluster = CassandraCluster(ec2_ami_id=self.params.get('ami_id_db_cassandra'),
@@ -97,6 +100,7 @@ class ClusterTester(Test):
                                                service=service,
                                                ec2_block_device_mappings=dbs_block_device_mappings,
                                                credentials=self.credentials,
+                                               user_prefix=user_prefix,
                                                n_nodes=n_db_nodes)
         else:
             self.error('Incorrect parameter db_type: %s' %
@@ -111,6 +115,7 @@ class ClusterTester(Test):
                                  ec2_block_device_mappings=loaders_block_device_mappings,
                                  credentials=self.credentials,
                                  scylla_repo=scylla_repo,
+                                 user_prefix=user_prefix,
                                  n_nodes=n_loader_nodes)
 
     def get_stress_cmd(self, duration=None, threads=None):


### PR DESCRIPTION
Introduce a cluster/db user prefix, so that we can tell apart
which instance belongs to whom. By default, it's the unix user
name of the user running the test, it can be overriden in the
YAML file if the user wants it to.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>