### PR TITLE
node: Monitor in real time the journal of all the nodes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -161,6 +161,14 @@ class Node(object):
         self._journal_thread = threading.Thread(target=self.journal_thread)
         self._journal_thread.start()
 
+    def get_backtraces(self):
+        try:
+            # get all the backtraces
+            self.remoter.run('sudo coredumpctl info',
+                             verbose=True, ignore_status=True)
+        except Exception, details:
+            self.log.error('Error retrieving backtraces : %s', details)
+
     def __str__(self):
         return 'Node %s [%s | %s] (seed: %s)' % (self.name,
                                                  self.instance.public_ip_address,
@@ -285,6 +293,10 @@ class Cluster(object):
     def run(self, cmd, verbose=False):
         for loader in self.nodes:
             loader.remoter.run(cmd=cmd, verbose=verbose)
+
+    def get_backtraces(self):
+        for node in self.nodes:
+            node.get_backtraces()
 
     def add_nodes(self, count, ec2_user_data=''):
         if not ec2_user_data:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -162,9 +162,11 @@ class ClusterTester(Test):
     def clean_resources(self):
         self.log.debug('Cleaning up resources used in the test')
         if self.db_cluster is not None:
+            self.db_cluster.get_backtraces()
             self.db_cluster.destroy()
             self.db_cluster = None
         if self.loaders is not None:
+            self.loader.get_backtraces()
             self.loaders.destroy()
             self.loaders = None
         if self.credentials is not None:


### PR DESCRIPTION
We need to be aware of what is happening on the running node.
This patch use the follow option of journal ctl to monitor
in real time the logs of the running nodes.

Signed-off-by: Benoît Canet <benoit@scylladb.com>