### PR TITLE
sdcm.tester: Work around https://github.com/boto/boto3/issues/220

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -25,6 +25,16 @@ from .cluster import RemoteCredentials
 from .cluster import ScyllaCluster
 from .data_path import get_data_path
 
+try:
+    from botocore.vendored.requests.packages.urllib3.contrib.pyopenssl import extract_from_urllib3
+
+    # Don't use pyOpenSSL in urllib3 - it causes an ``OpenSSL.SSL.Error``
+    # exception when we try an API call on an idled persistent connection.
+    # See https://github.com/boto/boto3/issues/220
+    extract_from_urllib3()
+except ImportError:
+    pass
+
 
 def clean_aws_resources(method):
     """


### PR DESCRIPTION
Our colleague Vlad Zoltarov reported the following problem:

    14:06:38 ERROR| Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado/core/test.py:388
    14:06:38 ERROR| Traceback (most recent call last):
    14:06:38 ERROR|   File "sdcm/tester.py", line 176, in tearDown
    14:06:38 ERROR|     self.clean_resources()
    14:06:38 ERROR|   File "sdcm/tester.py", line 165, in clean_resources
    14:06:38 ERROR|     self.db_cluster.destroy()
    14:06:38 ERROR|   File "sdcm/cluster.py", line 467, in destroy
    14:06:38 ERROR|     super(ScyllaCluster, self).destroy()
    14:06:38 ERROR|   File "sdcm/cluster.py", line 312, in destroy
    14:06:38 ERROR|     node.destroy()
    14:06:38 ERROR|   File "sdcm/cluster.py", line 167, in destroy
    14:06:38 ERROR|     self.instance.terminate()
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/boto3/resources/factory.py", line 455, in do_action
    14:06:38 ERROR|     response = action(self, *args, **kwargs)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/boto3/resources/action.py", line 79, in __call__
    14:06:38 ERROR|     response = getattr(parent.meta.client, operation_name)(**params)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/client.py", line 310, in _api_call
    14:06:38 ERROR|     return self._make_api_call(operation_name, kwargs)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/client.py", line 396, in _make_api_call
    14:06:38 ERROR|     operation_model, request_dict)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/endpoint.py", line 111, in make_request
    14:06:38 ERROR|     return self._send_request(request_dict, operation_model)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/endpoint.py", line 140, in _send_request
    14:06:38 ERROR|     success_response, exception):
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/endpoint.py", line 213, in _needs_retry
    14:06:38 ERROR|     caught_exception=caught_exception)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/hooks.py", line 226, in emit
    14:06:38 ERROR|     return self._emit(event_name, kwargs)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/hooks.py", line 209, in _emit
    14:06:38 ERROR|     response = handler(**kwargs)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/retryhandler.py", line 183, in __call__
    14:06:38 ERROR|     if self._checker(attempts, response, caught_exception):
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/retryhandler.py", line 250, in __call__
    14:06:38 ERROR|     caught_exception)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/retryhandler.py", line 265, in _should_retry
    14:06:38 ERROR|     return self._checker(attempt_number, response, caught_exception)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/retryhandler.py", line 313, in __call__
    14:06:38 ERROR|     caught_exception)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/retryhandler.py", line 222, in __call__
    14:06:38 ERROR|     return self._check_caught_exception(attempt_number, caught_exception)
    14:06:38 ERROR|   File "/usr/lib/python2.7/site-packages/botocore/retryhandler.py", line 355, in _check_caught_exception
    14:06:38 ERROR|     raise caught_exception
    14:06:38 ERROR| SysCallError: (32, 'EPIPE')

Which traces back to boto3 bug 220 [1]. This is a workaround
for that particular issue.

[1] https://github.com/boto/boto3/issues/220
