### PR TITLE
README.rst: Add more information on how to read logs

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -252,7 +252,7 @@ class Node(object):
         self.instance.stop()
         self.instance.wait_until_stopped()
         self.instance.start()
-        self.instance.wait_until_running()
+        self._wait_instance_up()
         self.wait_public_ip()
         self.log.debug('Got new public IP %s',
                        self.instance.public_ip_address)


### PR DESCRIPTION
The main test logs are hard to read, but that gets easier
if the user knows the high level overview of what is going
on. Give that overview and some examples of that in actual
log files.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>