### PR TITLE
sdcm.nemesis: Restart scylla service on our own on corrupt monkeys

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -324,7 +324,7 @@ class Node(object):
                                       verbose=False, ignore_status=True)
             return result.exit_status == 0
         except Exception, details:
-            self.log.error('Error checking for DB up: %s', details)
+            self.log.error('Error checking for DB status: %s', details)
             return False
 
     def cs_installed(self, cassandra_stress_bin=None):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -349,7 +349,7 @@ class Node(object):
         text = None
         if verbose:
             text = '%s: Waiting for DB services to be down' % self
-        wait.wait_for(func=lambda: not self.db_up, step=60,
+        wait.wait_for(func=lambda: not self.db_up(), step=60,
                       text=text)
 
     def wait_cs_installed(self, verbose=True):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -348,7 +348,7 @@ class Node(object):
     def wait_db_down(self, verbose=True):
         text = None
         if verbose:
-            text = '%s: Waiting for DB services to be up' % self
+            text = '%s: Waiting for DB services to be down' % self
         wait.wait_for(func=lambda: not self.db_up, step=60,
                       text=text)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -96,6 +96,12 @@ class Nemesis(object):
         self.target_node.remoter.run(kill_cmd, ignore_status=True)
 
         self.target_node.wait_db_down()
+
+        # TODO: Remove scylla-server restart upon systemd service is fixed
+        # https://github.com/scylladb/scylla/issues/904
+        restart_cmd = 'sudo systemctl restart scylla-server.service'
+        self.target_node.remoter.run(restart_cmd)
+
         # Let's wait for the target Node to have their services re-started
         self.target_node.wait_db_up()
 
@@ -109,7 +115,6 @@ class Nemesis(object):
         self.target_node.remoter.run('chmod +x /tmp/break_scylla.sh')
         self.target_node.remoter.run('/tmp/break_scylla.sh')
 
-        # lennart's systemd will restart scylla let him a bit of time
         self.disrupt_kill_scylla_daemon()
 
     def disrupt_destroy_data_then_repair(self):


### PR DESCRIPTION
Due to https://github.com/scylladb/scylla/issues/904, scylla will
not be restarted once it's killed. Let's restart it manually.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>