### PR TITLE
longevity_test.py: Increase default timeout to 650000 s

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -27,6 +27,8 @@ class LongevityTest(ClusterTester):
     :avocado: enable
     """
 
+    default_params = {'timeout': 650000}
+
     def test_custom_time(self):
         """
         Run cassandra-stress with params defined in data_dir/scylla.yaml

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -42,8 +42,8 @@ class Nemesis(object):
         self.log.info('Current Target: %s', self.target_node)
 
     def run(self, interval=30, termination_event=None):
-        self.log.info('Interval -> %s s', interval)
         interval *= 60
+        self.log.info('Interval -> %s s', interval)
         while True:
             time.sleep(interval)
             self.disrupt()


### PR DESCRIPTION
Right now avocado doesn't allow fine grained control of
test timeouts, so we have to select a default timeout for
all of those tests. Since the maximum amount of time a
test runs for is 604800 s (1 week), let's set 650000 s
as the timeout.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>