### PR TITLE
sdcm: Introduce Nemesis.report()

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -591,8 +591,6 @@ class ScyllaCluster(Cluster):
             node.wait_db_up(verbose=verbose)
             node.remoter.run('sudo yum install -y scylla-gdb',
                              verbose=verbose, ignore_status=True)
-            node.remoter.run('rpm -qa | grep scylla | sort', verbose=True,
-                             ignore_status=True)
             queue.put(node)
             queue.task_done()
 
@@ -636,6 +634,8 @@ class ScyllaCluster(Cluster):
             nemesis_thread.join(10)
 
     def destroy(self):
+        for nemesis in self.nemesis:
+            nemesis.report()
         self.stop_nemesis()
         super(ScyllaCluster, self).destroy()
 

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -500,7 +500,7 @@ class BaseRemote(object):
                         verbose=verbose)
                 try_scp = False
             except process.CmdError, e:
-                self.log.warn("Trying scp, rsync failed: %s", e)
+                self.log.warning("Trying scp, rsync failed: %s", e)
 
         if try_scp:
             # scp has no equivalent to --delete, just drop the entire dest dir
@@ -572,7 +572,7 @@ class BaseRemote(object):
                         verbose=verbose)
                 try_scp = False
             except process.CmdError, details:
-                self.log.warn("Trying scp, rsync failed: %s", details)
+                self.log.warning("Trying scp, rsync failed: %s", details)
 
         if try_scp:
             # scp has no equivalent to --delete, just drop the entire dest dir


### PR DESCRIPTION
Introduce a nemesis report, that summarizes the information
of the number of times a nemesis executed, its interval,
its average duration, and if we had unhandled exceptions
during the execution.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>