### PR TITLE
sdcm.cluster: Log properly multiple c-s executions

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -804,8 +804,8 @@ class LoaderSet(Cluster):
                 logdir = os.path.join(output_dir, self.name)
             result = node.remoter.run(cmd=stress_cmd, timeout=timeout,
                                       ignore_status=True)
-            log_file_name = os.path.join(logdir, '%s.log' % node.name)
-            self.log.debug('Writing log file %s', log_file_name)
+            log_file_name = os.path.join(logdir, 'cassandra-stress-%s.log' % uuid.uuid4())
+            self.log.debug('Writing cassandra-stress log %s', log_file_name)
             with open(log_file_name, 'w') as log_file:
                 log_file.write(str(result))
             queue.put((node, result))


### PR DESCRIPTION
Right now, more than one c-s execution on a test will overwrite
the file generated in the 'data' subdir. Let's rename the log
file and use a UUID to differentiate runs.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>