### PR TITLE
sdcm.cluster: Add scylla-io-setup.service logs

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -207,7 +207,9 @@ class Node(object):
     def retrieve_journal(self):
         try:
             log_file = os.path.join(self.logdir, 'db_services.log')
-            self.remoter.run('sudo journalctl -f -u scylla-server.service '
+            self.remoter.run('sudo journalctl -f '
+                             '-u scylla-io-setup.service '
+                             '-u scylla-server.service '
                              '-u scylla-jmx.service',
                              verbose=True, ignore_status=True,
                              log_file=log_file)


### PR DESCRIPTION
The new io setup service might be the source of new
problems, so let's add it to the roster of services
watched.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>