### PR TITLE
sdcm.nemesis: Don't wait for DB to be down on scylla daemon kill

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -143,7 +143,9 @@ class Nemesis(object):
         kill_cmd = "sudo pkill -9 scylla"
         self.target_node.remoter.run(kill_cmd, ignore_status=True)
 
-        self.target_node.wait_db_down()
+        # TODO: Due to scylla-server.service changing behavior
+        # now we don't wait the DB to be down
+        # self.target_node.wait_db_down()
 
         # TODO: Remove scylla-server restart upon systemd service is fixed
         # https://github.com/scylladb/scylla/issues/904


### PR DESCRIPTION
Now the service will restart it, so we have to skip that part.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>