### PR TITLE
Wait to start nemesis until cfstats reach a certain value

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -22,6 +22,11 @@ user_prefix:
 # Keep AWS instances running and leave credentials alone (keep)
 # Stop AWS instances and leave credentials alone (stop)
 failure_post_behavior: destroy
+# Space node treshold before starting nemesis (bytes)
+# The default value is 6GB (6x1024^3 bytes)
+# This value is supposed to reproduce
+# https://github.com/scylladb/scylla/issues/1140
+space_node_treshold: 6442450944
 
 regions: !mux
     us_west_1:

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -33,33 +33,38 @@ class LongevityTest(ClusterTester):
         """
         Run cassandra-stress with params defined in data_dir/scylla.yaml
         """
+        stress_queue = self.run_stress_thread(duration=self.params.get('cassandra_stress_duration'))
         self.db_cluster.add_nemesis(self.get_nemesis_class())
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
-        self.run_stress(duration=self.params.get('cassandra_stress_duration'))
+        self.verify_stress_thread(queue=stress_queue)
 
     def test_12_hours(self):
         """
         Run cassandra-stress on a cluster for 12 hours.
         """
+        stress_queue = self.run_stress(duration=60 * 12)
         self.db_cluster.add_nemesis(self.get_nemesis_class())
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
-        self.run_stress(duration=60 * 12)
+        self.verify_stress_thread(queue=stress_queue)
 
     def test_1_day(self):
         """
         Run cassandra-stress on a cluster for 24 hours.
         """
+        stress_queue = self.run_stress(duration=60 * 24)
         self.db_cluster.add_nemesis(self.get_nemesis_class())
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
-        self.run_stress(duration=60 * 24)
+        self.verify_stress_thread(queue=stress_queue)
 
     def test_1_week(self):
         """
         Run cassandra-stress on a cluster for 1 week.
         """
+        stress_queue = self.run_stress(duration=60 * 24 * 7)
         self.db_cluster.add_nemesis(self.get_nemesis_class())
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
-        self.run_stress(duration=60 * 24 * 7)
+        self.verify_stress_thread(queue=stress_queue)
+
 
 if __name__ == '__main__':
     main()

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -33,8 +33,10 @@ class LongevityTest(ClusterTester):
         """
         Run cassandra-stress with params defined in data_dir/scylla.yaml
         """
-        stress_queue = self.run_stress_thread(duration=self.params.get('cassandra_stress_duration'))
         self.db_cluster.add_nemesis(self.get_nemesis_class())
+        stress_queue = self.run_stress_thread(duration=self.params.get('cassandra_stress_duration'))
+        self.db_cluster.wait_cfstat_reached_treshold('Space used (total)',
+                                                     int(self.params.get('space_node_treshold')))
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         self.verify_stress_thread(queue=stress_queue)
 
@@ -42,8 +44,10 @@ class LongevityTest(ClusterTester):
         """
         Run cassandra-stress on a cluster for 12 hours.
         """
-        stress_queue = self.run_stress(duration=60 * 12)
         self.db_cluster.add_nemesis(self.get_nemesis_class())
+        stress_queue = self.run_stress(duration=60 * 12)
+        self.db_cluster.wait_cfstat_reached_treshold('Space used (total)',
+                                                     int(self.params.get('space_node_treshold')))
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         self.verify_stress_thread(queue=stress_queue)
 
@@ -51,8 +55,10 @@ class LongevityTest(ClusterTester):
         """
         Run cassandra-stress on a cluster for 24 hours.
         """
-        stress_queue = self.run_stress(duration=60 * 24)
         self.db_cluster.add_nemesis(self.get_nemesis_class())
+        stress_queue = self.run_stress(duration=60 * 24)
+        self.db_cluster.wait_cfstat_reached_treshold('Space used (total)',
+                                                     int(self.params.get('space_node_treshold')))
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         self.verify_stress_thread(queue=stress_queue)
 
@@ -60,8 +66,10 @@ class LongevityTest(ClusterTester):
         """
         Run cassandra-stress on a cluster for 1 week.
         """
-        stress_queue = self.run_stress(duration=60 * 24 * 7)
         self.db_cluster.add_nemesis(self.get_nemesis_class())
+        stress_queue = self.run_stress(duration=60 * 24 * 7)
+        self.db_cluster.wait_cfstat_reached_treshold('Space used (total)',
+                                                     int(self.params.get('space_node_treshold')))
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         self.verify_stress_thread(queue=stress_queue)
 

--- a/maintenance_test.py
+++ b/maintenance_test.py
@@ -13,6 +13,7 @@
 #
 # Copyright (c) 2016 ScyllaDB
 
+import time
 
 from avocado import main
 
@@ -37,6 +38,7 @@ class MaintainanceTest(ClusterTester):
         self.db_cluster.add_nemesis(DrainerMonkey)
         # this nemesis is not periodic and will do
         # the stop and restart
+        time.sleep(10 * 60)
         self.db_cluster.start_nemesis(interval=10)
         self.run_stress(duration=20)
 
@@ -47,6 +49,7 @@ class MaintainanceTest(ClusterTester):
         self.db_cluster.add_nemesis(CorruptThenRepairMonkey)
         # this nemesis is not periodic and will do
         # the stop and restart
+        time.sleep(10 * 60)
         self.db_cluster.start_nemesis(interval=10)
         self.run_stress(duration=20)
 
@@ -57,6 +60,7 @@ class MaintainanceTest(ClusterTester):
         self.db_cluster.add_nemesis(CorruptThenRebuildMonkey)
         # this nemesis is not periodic and will do
         # the stop and restart
+        time.sleep(10 * 60)
         self.db_cluster.start_nemesis(interval=10)
         self.run_stress(duration=20)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -57,12 +57,12 @@ class Nemesis(object):
         self.log.info('Interval: %s s', interval)
         self.interval = interval
         while True:
-            time.sleep(interval)
             self.disrupt()
             if termination_event is not None:
                 if self.termination_event.isSet():
                     self.termination_event = None
                     break
+            time.sleep(interval)
             self.set_target_node()
 
     def report(self):


### PR DESCRIPTION
Add a mechanism to only start nemesis when a certain column family statistic reaches a certain treshold, such as disk space occupied by a keyspace on a given node. Also, modify the behavior of nemesis ever so slightly, so that disruption function starts right away on nemesis.start().