### PR TITLE
sdcm.tester: Increase data size on nodes

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -220,7 +220,7 @@ class ClusterTester(Test):
         return ("cassandra-stress write cl=QUORUM duration=%sm "
                 "-schema 'replication(factor=3)' -port jmx=6868 "
                 "-mode cql3 native -rate threads=%s "
-                "-node %s" % (duration, threads, ip))
+                "-pop seq=1..100000000 -node %s" % (duration, threads, ip))
 
     @clean_aws_resources
     def run_stress(self, stress_cmd=None, duration=None):


### PR DESCRIPTION
In order to better stress the cluster, let's add a -pop seq
argument, to ensure we are writing a large amount of table
data to each node.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>