### PR TITLE
Create a way to test upgrades

### DIFF
--- a/data_dir/scylla.repo.upgrade
+++ b/data_dir/scylla.repo.upgrade
@@ -1,0 +1,23 @@
+[scylla]
+name=Scylla for Centos $releasever - $basearch
+baseurl=http://downloads.scylladb.com/rpm/unstable/centos/branch-1.1/1/scylla/$releasever/$basearch/
+enabled=1
+gpgcheck=0
+
+[scylla-generic]
+name=Scylla for centos $releasever
+baseurl=http://downloads.scylladb.com/rpm/unstable/centos/branch-1.1/1/scylla/$releasever/noarch/
+enabled=1
+gpgcheck=0
+
+[scylla-3rdparty]
+name=Scylla 3rdParty for Centos $releasever - $basearch
+baseurl=http://downloads.scylladb.com/rpm/unstable/centos/branch-1.1/1/3rdparty/$releasever/$basearch/
+enabled=1
+gpgcheck=0
+
+[scylla-3rdparty-generic]
+name=Scylla 3rdParty for Centos $releasever
+baseurl=http://downloads.scylladb.com/rpm/unstable/centos/branch-1.1/1/3rdparty/$releasever/noarch/
+enabled=1
+gpgcheck=0

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -294,3 +294,35 @@ class ChaosMonkey(Nemesis):
     @log_time_elapsed
     def disrupt(self):
         self.call_random_disrupt_method()
+
+class UpgradeNemesis(Nemesis):
+
+    # upgrade a single node
+    def upgrade_node(self, node):
+        self.log.info('Upgrading a Node')
+        scylla_repo = get_data_path('scylla.repo.upgrade')
+        node.remoter.send_files(scylla_repo, '/tmp/scylla.repo', verbose=True)
+        node.remoter.run('sudo cp /tmp/scylla.repo /etc/yum.repos.d/scylla.repo')
+        node.remoter.run('sudo chown root.root /etc/yum.repos.d/scylla.repo')
+        node.remoter.run('sudo chmod 644 /etc/yum.repos.d/scylla.repo')
+        node.remoter.run('sudo yum update scylla scylla-conf scylla-server scylla-jmx scylla-tools -y')
+        node.remoter.run('sudo systemctl restart scylla-server.service')
+        node.remoter.run('sudo systemctl restart scylla-jmx.service')
+
+    @log_time_elapsed
+    def disrupt(self):
+        self.log.info('Upgrade Nemesis begin')
+        # get the number of nodes
+        l = len(self.cluster.nodes)
+        # prepare an array containing the indexes
+        indexes = [ x for x in range(l) ]
+        # shuffle it so we will upgrade the nodes in a
+        # random order
+        random.shuffle(indexes)
+
+        # upgrade all the nodes in random order
+        for i in indexes:
+            node = self.cluster.nodes[i]
+            self.upgrade_node(node)
+
+        self.log.info('Upgrade Nemesis end')

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -199,6 +199,13 @@ class ClusterTester(Test):
                                  user_prefix=user_prefix,
                                  n_nodes=n_loader_nodes)
 
+        # Share params with the clusters
+        self.db_cluster.params = self.params
+        self.loaders.params = self.params
+
+        # cross reference
+        self.loaders.db_cluster = self.db_cluster
+
     def get_stress_cmd(self, duration=None, threads=None):
         """
         Get a cassandra stress cmd string.


### PR DESCRIPTION
This patch allows to do live upgrades during a
test run.

It's enabled by setting test_upgrade: 'True'
in the yaml file.

Signed-off-by: Benoît Canet <benoit@scylladb.com>