### PR TITLE
Introduce update_db_binary option

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -28,6 +28,12 @@ failure_post_behavior: destroy
 # https://github.com/scylladb/scylla/issues/1140
 space_node_treshold: 6442450944
 
+# The new db binary will be uploaded to db instance to replace the one
+# provided by the ami. This is useful to test out a new scylla version
+# without making a new ami.
+# update_db_binary: $path_of_the_new_scylla_binary
+update_db_binary: ''
+
 regions: !mux
     us_west_1:
         region_name: 'us-west-1'

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -693,6 +693,8 @@ class ScyllaCluster(Cluster):
             except Queue.Empty:
                 pass
 
+        self.update_db_binary(node_list)
+
         self.get_seed_nodes()
         time_elapsed = time.time() - start_time
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
@@ -726,6 +728,32 @@ class ScyllaCluster(Cluster):
     def destroy(self):
         self.stop_nemesis()
         super(ScyllaCluster, self).destroy()
+
+    def update_db_binary(self, node_list=None):
+        if node_list is None:
+            node_list = self.nodes
+
+        new_scylla_bin = self.params.get('update_db_binary')
+        if new_scylla_bin != '':
+            for node in node_list:
+                self.log.info('Upgrading a DB binary for Node')
+
+                node.remoter.send_files(new_scylla_bin, '/tmp/scylla', verbose=True)
+
+                # stop scylla-server before replace the binary
+                node.remoter.run('sudo systemctl stop scylla-server.service')
+
+                # replace the binary
+                node.remoter.run('sudo cp -f /usr/bin/scylla /usr/bin/scylla.origin')
+                node.remoter.run('sudo cp -f /tmp/scylla /usr/bin/scylla')
+                node.remoter.run('sudo chown root.root /usr/bin/scylla')
+                node.remoter.run('sudo chmod +x  /usr/bin/scylla')
+
+                node.remoter.run('sudo systemctl restart scylla-server.service')
+                node.remoter.run('sudo systemctl restart scylla-jmx.service')
+            # Wait for DB is up
+            for node in node_list:
+                node.wait_db_up()
 
 
 class CassandraCluster(ScyllaCluster):


### PR DESCRIPTION
The new db binary will be uploaded to db instance to replace the one
provided by the ami. This is useful to test out a new scylla version
without making a new ami.

Edit data_dir/scylla.yaml as:

update_db_binary: $path_of_the_new_scylla_binary