### PR TITLE
Less stress

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -11,7 +11,7 @@ n_loaders: 1
 # loader instance by default.
 instance_type_loader: 'c3.large'
 # Nemesis class to use (possible types in sdcm.nemesis). Example: StopStartMonkey
-nemesis_class_name: 'StopStartMonkey'
+nemesis_class_name: 'ChaosMonkey'
 # Nemesis sleep interval to use if None provided specifically
 nemesis_interval: 15
 # Prefix for your AWS VMs (handy for telling instances from different

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -186,7 +186,9 @@ class Nemesis(object):
                     new_nodes = self.cluster.add_nodes(count=1)
                     self.cluster.wait_for_init(node_list=new_nodes)
 
-    def disrupt_stop_start(self):
+    def _deprecated_disrupt_stop_start(self):
+        # TODO: We don't support fully stopping the AMI instance anymore
+        # TODO: This nemesis has to be rewritten to just stop/start scylla server
         self.log.info('StopStart %s', self.target_node)
         self.target_node.restart()
 
@@ -252,7 +254,7 @@ class StopStartMonkey(Nemesis):
 
     @log_time_elapsed
     def disrupt(self):
-        self.disrupt_stop_start()
+        self._deprecated_disrupt_stop_start()
 
 
 class DrainerMonkey(Nemesis):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -230,7 +230,7 @@ class ClusterTester(Test):
         return ("cassandra-stress write cl=QUORUM duration=%sm "
                 "-schema 'replication(factor=3)' -port jmx=6868 "
                 "-mode cql3 native -rate threads=%s "
-                "-pop seq=1..100000000 -node %s" % (duration, threads, ip))
+                "-pop seq=1..10000000 -node %s" % (duration, threads, ip))
 
     @clean_aws_resources
     def run_stress(self, stress_cmd=None, duration=None):


### PR DESCRIPTION
Let's write less data to nodes. Also, remove the current stop/start nemesis from the list of nemesis that can be executed on a ChaosMonkey, and let's make ChaosMonkey the default nemesis.