### PR TITLE
sdcm.cluster: Ignore killall tcpdump errors

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -437,7 +437,7 @@ class Node(object):
                            'debugging info', tcpdump_id)
             raise
         finally:
-            self.remoter.run('sudo killall tcpdump')
+            self.remoter.run('sudo killall tcpdump', ignore_status=True)
         self.log.info('END tcpdump thread uuid: %s', tcpdump_id)
         return self._parse_cfstats(result.stdout)
 


### PR DESCRIPTION
Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>